### PR TITLE
Increase mobile font sizes for better readability

### DIFF
--- a/Al_Hamichya_files/mainStyle.css
+++ b/Al_Hamichya_files/mainStyle.css
@@ -428,3 +428,26 @@ img{
 	padding-right: 10px;
 	margin-right: 5px;
 }
+
+@media (max-width: 768px) {
+	html {
+		font-size: 112%;
+	}
+
+	.title {
+		font-size: 2.3em;
+	}
+
+	.type-option {
+		font-size: 1.15em;
+	}
+
+	.hpar {
+		font-size: 1.9em;
+		line-height: 1.85em;
+	}
+
+	.instr {
+		font-size: 1.05em;
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve readability on small screens by increasing typography scale for key content elements.
- Target the Hebrew prayer text and UI labels that are hard to read on mobile devices.

### Description
- Add a mobile-only media query `@media (max-width: 768px)` in `Al_Hamichya_files/mainStyle.css` to scope changes to phones.
- Increase base mobile scale via `html { font-size: 112%; }` and enlarge `.title`, `.type-option`, `.hpar`, and `.instr` for better legibility.
- Keep desktop styles unchanged by limiting adjustments to the mobile media query.

### Testing
- Reviewed the CSS diff with `git diff -- Al_Hamichya_files/mainStyle.css` which showed only typography adjustments and succeeded.
- Served the site using `python3 -m http.server 4173 --bind 0.0.0.0` to verify the running site and succeeded.
- Captured a mobile viewport screenshot using Playwright (`390x844`) against `http://127.0.0.1:4173/index.html` to validate visual impact and succeeded.
- Committed the change and verified with `git show --stat --oneline` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698515e8f64083288eba362b9a566c1c)