### PR TITLE
Implement WCAG AA accessibility improvements

### DIFF
--- a/Al_Hamichya.html
+++ b/Al_Hamichya.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!-- saved from url=(0034)http://www.brochos.com/brochos/ahm -->
-<html>
+<html lang="he" dir="rtl">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	  <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,10 +9,10 @@
       <link rel="icon" href="./Al_Hamichya_files/cookie.jpg" type="image/x-icon">
       <link rel="stylesheet" type="text/css" href="./Al_Hamichya_files/mainStyle.css">
 
-      <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 	  
-      <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.3/themes/smoothness/jquery-ui.css">
-      <script src="https://code.jquery.com/ui/1.11.3/jquery-ui.min.js"></script>
+      <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.14.0/themes/smoothness/jquery-ui.css">
+      <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.14.0/jquery-ui.min.js"></script>
 
       <style media="print" type="text/css">
          body{
@@ -69,21 +69,25 @@
       </style>
    </head>
    <body onload="">
+      <a href="#main-content" class="skip-link" lang="en">Skip to main content</a>
       <div class="cdiv">
          <div class="cdivs">
             <div class="narrow" id="mmnarrow">
                <div class="">
 			   
+				  <header>
 				  <div id="actionBox" class="actionBox">
 					  <h1 class="title">ברכת מעין שלש</h1>
 
-					  <img class="toggleImg" id="Mezonos" alt="Mezonos" src="./Al_Hamichya_files/cookie.jpg" />                  
-					  <img class="toggleImg" id="Wine" alt="Wine" src="./Al_Hamichya_files/wine.jpg" />
-					  <img class="toggleImg" id="ShivasHaminim" alt="Shivas Haminim" src="./Al_Hamichya_files/pomegranate.jpg" />
+					  <img class="toggleImg" id="Mezonos" alt="Mezonos" src="./Al_Hamichya_files/cookie.jpg" role="button" tabindex="0" aria-pressed="true" />                  
+					  <img class="toggleImg" id="Wine" alt="Wine" src="./Al_Hamichya_files/wine.jpg" role="button" tabindex="0" aria-pressed="false" />
+					  <img class="toggleImg" id="ShivasHaminim" alt="Shivas Haminim" src="./Al_Hamichya_files/pomegranate.jpg" role="button" tabindex="0" aria-pressed="false" />
 				  </div>
+				  </header>
 				  
 				  <hr />
 				  
+                  <main id="main-content" tabindex="-1">
                   <div class="article barticle">
                      <p class="hpar" style="">בָּרוּךְ אַתָּה יהוה אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם,</p>
 
@@ -106,17 +110,17 @@
 					 </p>
 
                      <div id="accordion" style="background-color: #DDDDDD; ">
-                        <h2>Rosh Chodesh</h2>
+                        <h2 lang="en">Rosh Chodesh</h2>
                         <div>                           
                            <p class="hpar accordion-hpar" style="">וְזָכְרֵנוּ לְטוֹבָה בְּיוֹם רֹאש הַחֹדֶשׁ הַזֶה.</p>
                         </div>
 
-                        <h2>Pesach</h2>
+                        <h2 lang="en">Pesach</h2>
                         <div>    
                            <p class="hpar accordion-hpar" style="">וְשַׂמְּחֵנוּ בְּיוֹם חַג הַמַּצּוֹת הַזֶה.</p>
                         </div>
 
-                        <h2>Sukkos</h2>
+                        <h2 lang="en">Sukkos</h2>
                         <div>    
                            <p class="hpar accordion-hpar" style="">וְשַׂמְּחֵנוּ בְּיוֹם חַג הַסֻּכּוֹת הַזֶה.</p>
                         </div>
@@ -130,13 +134,13 @@
 
                      <div class="AlHagaphen type-option" style="background-color: #FAAFBA; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל פְּרִי הַגָּפֶן</p>
-                        <p class="instr" style="">* If the wine is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the wine is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פְּרִי גַפְנָהּ</p>
                      </div>
 
                      <div class="AlHaeitz type-option" style="background-color: #90EE90; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל הַפֵּרוֹת</p>
-                        <p class="instr" style="">* If the fruit is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the fruit is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פֵּירוֹתֶיהָ.</p>
                      </div>
 
@@ -148,17 +152,16 @@
 
                      <div class="AlHagaphen type-option" style="background-color: #FAAFBA; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל פְּרִי הַגָּפֶן</p>
-                        <p class="instr" style="">* If the wine is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the wine is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פְּרִי גַפְנָהּ</p>
                      </div>
 
                      <div class="AlHaeitz type-option" style="background-color: #90EE90; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל הַפֵּרוֹת</p>
-                        <p class="instr" style="">* If the fruit is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the fruit is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פֵּירוֹתֶיהָ.</p>
-                     </div>
-
-                  </div>
+                           </div>
+                  </main>
                </div>
             </div>
          </div>
@@ -188,11 +191,22 @@
              checkImage("ShivasHaminim");
          });
 
+         $('.toggleImg').on('keydown', function(e)
+         {
+             if (e.key === 'Enter' || e.key === ' ')
+             {
+                 e.preventDefault();
+                 $(this).trigger('click');
+             }
+         });
+
          function checkImage(id) 
          {            
             var opacity = $("#" + id).css('opacity');
+            var isActive = parseFloat(opacity).toFixed(1) !== '0.4';
+            $("#" + id).attr('aria-pressed', isActive);
 
-            if (parseFloat(opacity).toFixed(1) === '0.4') 
+            if (!isActive) 
             {
                sectionShowHide(id, false)
             } 

--- a/Al_Hamichya_files/mainStyle.css
+++ b/Al_Hamichya_files/mainStyle.css
@@ -1,5 +1,36 @@
 a {color:blue}
 
+/* Skip navigation link (hidden until focused) */
+.skip-link {
+    position: absolute;
+    top: -50px;
+    left: 0;
+    background: #000;
+    color: #fff;
+    padding: 8px 16px;
+    z-index: 9999;
+    font-size: 1rem;
+    text-decoration: none;
+    border-radius: 0 0 4px 0;
+    transition: top 0.2s;
+}
+.skip-link:focus {
+    top: 0;
+}
+
+/* Screen-reader-only utility */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 html{
 	font-size:100%;
 }
@@ -238,6 +269,16 @@ img{
 	cursor: pointer;
 }
 
+.toggleImg:focus-visible {
+	outline: 3px solid #005fcc;
+	outline-offset: 3px;
+}
+
+#theme-toggle:focus-visible {
+	outline: 3px solid #005fcc;
+	outline-offset: 2px;
+}
+
 #searcher .box{
 	background-color:#FFDC8A;
 }
@@ -428,6 +469,18 @@ img{
 	padding-left: 10px;
 	padding-right: 10px;
 	margin-right: 5px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+	.skip-link {
+		transition: none;
+	}
 }
 
 @media (max-width: 750px) {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<html lang="he" dir="rtl">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	  <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -71,22 +71,26 @@
       </style>
    </head>
    <body onload="">
+      <a href="#main-content" class="skip-link" lang="en">Skip to main content</a>
       <div class="cdiv">
          <div class="cdivs">
             <div class="narrow" id="mmnarrow">
                <div class="">
 			   
+				  <header>
 				  <div id="actionBox" class="actionBox">
-					  <button id="theme-toggle"></button>
+					  <button id="theme-toggle" aria-label="Toggle dark/light theme"></button>
 					  <h1 class="title">ברכת מעין שלש</h1>
 
-					  <img class="toggleImg" id="Mezonos" alt="Mezonos" src="./Al_Hamichya_files/cookie.jpg" />                  
-					  <img class="toggleImg" id="Wine" alt="Wine" src="./Al_Hamichya_files/wine.jpg" />
-					  <img class="toggleImg" id="ShivasHaminim" alt="Shivas Haminim" src="./Al_Hamichya_files/pomegranate.jpg" />
+					  <img class="toggleImg" id="Mezonos" alt="Mezonos" src="./Al_Hamichya_files/cookie.jpg" role="button" tabindex="0" aria-pressed="true" />                  
+					  <img class="toggleImg" id="Wine" alt="Wine" src="./Al_Hamichya_files/wine.jpg" role="button" tabindex="0" aria-pressed="false" />
+					  <img class="toggleImg" id="ShivasHaminim" alt="Shivas Haminim" src="./Al_Hamichya_files/pomegranate.jpg" role="button" tabindex="0" aria-pressed="false" />
 				  </div>
+				  </header>
 				  
 				  <hr />
 				  
+                  <main id="main-content" tabindex="-1">
                   <div class="article barticle">
                      <p class="hpar" style="">בָּרוּךְ אַתָּה יהוה אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם,</p>
 
@@ -110,17 +114,17 @@
 					 </p>
 
                      <div id="accordion" >
-                        <h2>Rosh Chodesh</h2>
+                        <h2 lang="en">Rosh Chodesh</h2>
                         <div>                           
                            <p class="hpar accordion-hpar" style="">וְזָכְרֵנוּ לְטוֹבָה בְּיוֹם רֹאש הַחֹדֶשׁ הַזֶה.</p>
                         </div>
 
-                        <h2>Pesach</h2>
+                        <h2 lang="en">Pesach</h2>
                         <div>    
                            <p class="hpar accordion-hpar" style="">וְשַׂמְּחֵנוּ בְּיוֹם חַג הַמַּצּוֹת הַזֶה.</p>
                         </div>
 
-                        <h2>Sukkos</h2>
+                        <h2 lang="en">Sukkos</h2>
                         <div>    
                            <p class="hpar accordion-hpar" style="">וְשַׂמְּחֵנוּ בְּיוֹם חַג הַסֻּכּוֹת הַזֶה.</p>
                         </div>
@@ -134,13 +138,13 @@
 
                      <div class="AlHagaphen type-option" style="background-color: #FAAFBA; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל פְּרִי הַגָּפֶן</p>
-                        <p class="instr" style="">* If the wine is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the wine is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פְּרִי גַפְנָהּ</p>
                      </div>
 
                      <div class="AlHaeitz type-option" style="background-color: #90EE90; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל הַפֵּרוֹת</p>
-                        <p class="instr" style="">* If the fruit is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the fruit is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פֵּירוֹתֶיהָ.</p>
                      </div>
 
@@ -152,17 +156,16 @@
 
                      <div class="AlHagaphen type-option" style="background-color: #FAAFBA; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל פְּרִי הַגָּפֶן</p>
-                        <p class="instr" style="">* If the wine is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the wine is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פְּרִי גַפְנָהּ</p>
                      </div>
 
                      <div class="AlHaeitz type-option" style="background-color: #90EE90; ">
                         <p class="hpar" style="margin-bottom: 0;">וְעַל הַפֵּרוֹת</p>
-                        <p class="instr" style="">* If the fruit is from Eretz Yisrael, some substitute with:</p>
+                        <p class="instr" style="" lang="en">* If the fruit is from Eretz Yisrael, some substitute with:</p>
                         <p class="hpar" style="">וְעַל פֵּירוֹתֶיהָ.</p>
-                     </div>
-
-                  </div>
+                           </div>
+                  </main>
                </div>
             </div>
          </div>
@@ -192,11 +195,22 @@
              checkImage("ShivasHaminim");
          });
 
+         $('.toggleImg').on('keydown', function(e)
+         {
+             if (e.key === 'Enter' || e.key === ' ')
+             {
+                 e.preventDefault();
+                 $(this).trigger('click');
+             }
+         });
+
          function checkImage(id) 
          {            
             var opacity = $("#" + id).css('opacity');
+            var isActive = parseFloat(opacity).toFixed(1) !== '0.4';
+            $("#" + id).attr('aria-pressed', isActive);
 
-            if (parseFloat(opacity).toFixed(1) === '0.4') 
+            if (!isActive) 
             {
                sectionShowHide(id, false)
             } 


### PR DESCRIPTION
## Summary
Implements all accessibility improvements identified in the WCAG AA audit.

## Changes

### Critical fixes
- **WCAG 3.1.1** — Added `lang="he" dir="rtl"` to `<html>` on both pages so screen readers select the correct Hebrew TTS engine
- **WCAG 4.1.2** — Added `aria-label="Toggle dark/light theme"` to the theme toggle button (`index.html`)
- **WCAG 2.1.1 + 4.1.2** — Toggle images are now keyboard-accessible: `role="button"`, `tabindex="0"`, `aria-pressed` state, and an `Enter`/`Space` `keydown` handler

### Serious fixes
- **WCAG 2.4.1** — Added a visually-hidden skip-to-main-content link that becomes visible on focus
- **WCAG 1.3.1** — Added `<header>` around the actionBox and `<main id="main-content">` around the prayer text
- **WCAG 2.4.7** — Added `:focus-visible` outlines for `.toggleImg` and `#theme-toggle` (3 px solid blue)

### Moderate fixes
- **WCAG 3.1.2** — Added `lang="en"` to all English-language passages (`.instr` paragraphs and accordion `<h2>` headings)
- **WCAG 2.3.3** — Added `@media (prefers-reduced-motion: reduce)` block to suppress animations/transitions for users who prefer it
- **Security / mixed content** — Upgraded `Al_Hamichya.html` jQuery from HTTP 1.11.2 → HTTPS 3.7.1 and jQuery UI from 1.11.3 → 1.14.0

### CSS additions (`mainStyle.css`)
- `.skip-link` — slide-in-on-focus pattern
- `.visually-hidden` — standard screen-reader-only utility class
- `focus-visible` rules for interactive elements
- `prefers-reduced-motion` media query

_This PR was generated with [Oz](https://www.warp.dev/oz)._
